### PR TITLE
Fix fd leak in TcpClient::disConnect

### DIFF
--- a/dobot_bringup_v4/src/tcp_socket.cpp
+++ b/dobot_bringup_v4/src/tcp_socket.cpp
@@ -44,11 +44,21 @@ void TcpClient::connect()
 
 void TcpClient::disConnect()
 {
+    // Close the real fd BEFORE setting fd_ = -1. Previously the order
+    // was reversed, so ::close(fd_) ran with fd_ already set to -1,
+    // making the call a no-op and leaking the socket. No FIN was sent
+    // to the robot, and the dashboard server kept tracking the stale
+    // session as live — subsequent connects were rejected with
+    // "Connection refused, IP:Port has been occupied" until the
+    // robot was power-cycled.
     if (is_connected_)
     {
+        if (fd_ >= 0)
+        {
+            ::close(fd_);
+        }
         fd_ = -1;
         is_connected_ = false;
-        ::close(fd_);
     }
 }
 


### PR DESCRIPTION
## Summary

`TcpClient::disConnect()` in `dobot_bringup_v4/src/tcp_socket.cpp` set `fd_ = -1` **before** calling `::close(fd_)`, so `close` ran on the already-cleared fd value (a no-op on `-1`) and the real socket was leaked. The kernel never sent a FIN to the peer, so the robot's dashboard server (port 29999) kept tracking each closed session as live. Subsequent connects from the same client IP were then rejected with:

```
Connection refused, IP:Port has been occupied
```

…until the robot was power-cycled to clear its internal session table.

## The fix

Three-line reorder — close the real fd first, then set `fd_ = -1`, then clear `is_connected_`. A guard on `fd_ >= 0` avoids calling `close` on an already-cleared descriptor.

```cpp
void TcpClient::disConnect()
{
    if (is_connected_)
    {
        if (fd_ >= 0)
        {
            ::close(fd_);
        }
        fd_ = -1;
        is_connected_ = false;
    }
}
```

## Impact seen in the field

Under continuous streaming commands (`ServoP`, etc.), every transient TCP error path through `tcpSend` or `tcpRecv` calls `disConnect` and leaks one fd. After ~1 hour of operation the driver process on our machine held **800+ leaked socket fds**, and the robot's session tracker eventually refused any further connections from the client IP. A full robot power-cycle was the only way to recover — a container / docker restart wasn't enough because the phantom sessions live on the robot side.

With the fix applied, disConnect actually tears down the socket and sends a FIN; the robot releases its slot immediately and reconnects work normally.

## Test plan

- [x] Ran our continuous ServoP streaming test for 10+ minutes against a real CR5 with the patched driver. Previously this would brick the command path within 2-3 minutes; now it runs indefinitely.
- [x] Checked `ls /proc/<pid>/fd | grep socket | wc -l` on the running driver — stays stable at ~15-20 fds instead of climbing to the hundreds.
- [x] Forced repeated watchdog restarts of the ROS node while streaming. Each restart cleanly reclaims the 29999 slot; no "IP:Port has been occupied" after N cycles.