### PR TITLE
Port simulation to ROS 2 Jazzy 

### DIFF
--- a/cr10_moveit/package.xml
+++ b/cr10_moveit/package.xml
@@ -28,7 +28,8 @@
   <exec_depend>xacro</exec_depend>
   <!-- The next 2 packages are required for the gazebo simulation.
        We don't include them by default to prevent installing gazebo and all its dependencies. -->
-  <!-- <exec_depend>joint_trajectory_controller</exec_depend> -->
+  <exec_depend>joint_trajectory_controller</exec_depend>
+  <exec_depend>joint_state_broadcaster</exec_depend>
   <!-- <exec_depend>gazebo_ros_control</exec_depend> -->
   <exec_depend>controller_manager</exec_depend>
   <exec_depend>dobot_rviz</exec_depend>
@@ -42,7 +43,7 @@
   <exec_depend>rviz_common</exec_depend>
   <exec_depend>rviz_default_plugins</exec_depend>
   <exec_depend>tf2_ros</exec_depend>
-  <exec_depend>warehouse_ros_mongo</exec_depend>
+  <exec_depend>warehouse_ros_sqlite</exec_depend>
   <exec_depend>xacro</exec_depend>
 
 

--- a/cr10af_moveit/package.xml
+++ b/cr10af_moveit/package.xml
@@ -28,7 +28,8 @@
   <exec_depend>xacro</exec_depend>
   <!-- The next 2 packages are required for the gazebo simulation.
        We don't include them by default to prevent installing gazebo and all its dependencies. -->
-  <!-- <exec_depend>joint_trajectory_controller</exec_depend> -->
+  <exec_depend>joint_trajectory_controller</exec_depend>
+  <exec_depend>joint_state_broadcaster</exec_depend>
   <!-- <exec_depend>gazebo_ros_control</exec_depend> -->
   <exec_depend>controller_manager</exec_depend>
   <exec_depend>dobot_rviz</exec_depend>
@@ -42,7 +43,7 @@
   <exec_depend>rviz_common</exec_depend>
   <exec_depend>rviz_default_plugins</exec_depend>
   <exec_depend>tf2_ros</exec_depend>
-  <exec_depend>warehouse_ros_mongo</exec_depend>
+  <exec_depend>warehouse_ros_sqlite</exec_depend>
   <exec_depend>xacro</exec_depend>
 
 

--- a/cr12_moveit/package.xml
+++ b/cr12_moveit/package.xml
@@ -28,7 +28,8 @@
   <exec_depend>xacro</exec_depend>
   <!-- The next 2 packages are required for the gazebo simulation.
        We don't include them by default to prevent installing gazebo and all its dependencies. -->
-  <!-- <exec_depend>joint_trajectory_controller</exec_depend> -->
+  <exec_depend>joint_trajectory_controller</exec_depend>
+  <exec_depend>joint_state_broadcaster</exec_depend>
   <!-- <exec_depend>gazebo_ros_control</exec_depend> -->
   <exec_depend>controller_manager</exec_depend>
   <exec_depend>dobot_rviz</exec_depend>
@@ -42,7 +43,7 @@
   <exec_depend>rviz_common</exec_depend>
   <exec_depend>rviz_default_plugins</exec_depend>
   <exec_depend>tf2_ros</exec_depend>
-  <exec_depend>warehouse_ros_mongo</exec_depend>
+  <exec_depend>warehouse_ros_sqlite</exec_depend>
   <exec_depend>xacro</exec_depend>
 
 

--- a/cr16_moveit/package.xml
+++ b/cr16_moveit/package.xml
@@ -28,7 +28,8 @@
   <exec_depend>xacro</exec_depend>
   <!-- The next 2 packages are required for the gazebo simulation.
        We don't include them by default to prevent installing gazebo and all its dependencies. -->
-  <!-- <exec_depend>joint_trajectory_controller</exec_depend> -->
+  <exec_depend>joint_trajectory_controller</exec_depend>
+  <exec_depend>joint_state_broadcaster</exec_depend>
   <!-- <exec_depend>gazebo_ros_control</exec_depend> -->
   <exec_depend>controller_manager</exec_depend>
   <exec_depend>dobot_rviz</exec_depend>
@@ -42,7 +43,7 @@
   <exec_depend>rviz_common</exec_depend>
   <exec_depend>rviz_default_plugins</exec_depend>
   <exec_depend>tf2_ros</exec_depend>
-  <exec_depend>warehouse_ros_mongo</exec_depend>
+  <exec_depend>warehouse_ros_sqlite</exec_depend>
   <exec_depend>xacro</exec_depend>
 
 

--- a/cr20_moveit/package.xml
+++ b/cr20_moveit/package.xml
@@ -28,7 +28,8 @@
   <exec_depend>xacro</exec_depend>
   <!-- The next 2 packages are required for the gazebo simulation.
        We don't include them by default to prevent installing gazebo and all its dependencies. -->
-  <!-- <exec_depend>joint_trajectory_controller</exec_depend> -->
+  <exec_depend>joint_trajectory_controller</exec_depend>
+  <exec_depend>joint_state_broadcaster</exec_depend>
   <!-- <exec_depend>gazebo_ros_control</exec_depend> -->
   <exec_depend>controller_manager</exec_depend>
   <exec_depend>dobot_rviz</exec_depend>
@@ -42,7 +43,7 @@
   <exec_depend>rviz_common</exec_depend>
   <exec_depend>rviz_default_plugins</exec_depend>
   <exec_depend>tf2_ros</exec_depend>
-  <exec_depend>warehouse_ros_mongo</exec_depend>
+  <exec_depend>warehouse_ros_sqlite</exec_depend>
   <exec_depend>xacro</exec_depend>
 
 

--- a/cr30h_moveit/package.xml
+++ b/cr30h_moveit/package.xml
@@ -28,7 +28,8 @@
   <exec_depend>xacro</exec_depend>
   <!-- The next 2 packages are required for the gazebo simulation.
        We don't include them by default to prevent installing gazebo and all its dependencies. -->
-  <!-- <exec_depend>joint_trajectory_controller</exec_depend> -->
+  <exec_depend>joint_trajectory_controller</exec_depend>
+  <exec_depend>joint_state_broadcaster</exec_depend>
   <!-- <exec_depend>gazebo_ros_control</exec_depend> -->
   <exec_depend>controller_manager</exec_depend>
   <exec_depend>dobot_rviz</exec_depend>
@@ -42,7 +43,7 @@
   <exec_depend>rviz_common</exec_depend>
   <exec_depend>rviz_default_plugins</exec_depend>
   <exec_depend>tf2_ros</exec_depend>
-  <exec_depend>warehouse_ros_mongo</exec_depend>
+  <exec_depend>warehouse_ros_sqlite</exec_depend>
   <exec_depend>xacro</exec_depend>
 
 

--- a/cr3_moveit/package.xml
+++ b/cr3_moveit/package.xml
@@ -28,7 +28,8 @@
   <exec_depend>xacro</exec_depend>
   <!-- The next 2 packages are required for the gazebo simulation.
        We don't include them by default to prevent installing gazebo and all its dependencies. -->
-  <!-- <exec_depend>joint_trajectory_controller</exec_depend> -->
+  <exec_depend>joint_trajectory_controller</exec_depend>
+  <exec_depend>joint_state_broadcaster</exec_depend>
   <!-- <exec_depend>gazebo_ros_control</exec_depend> -->
   <exec_depend>controller_manager</exec_depend>
   <exec_depend>dobot_rviz</exec_depend>
@@ -42,7 +43,7 @@
   <exec_depend>rviz_common</exec_depend>
   <exec_depend>rviz_default_plugins</exec_depend>
   <exec_depend>tf2_ros</exec_depend>
-  <exec_depend>warehouse_ros_mongo</exec_depend>
+  <exec_depend>warehouse_ros_sqlite</exec_depend>
   <exec_depend>xacro</exec_depend>
 
 

--- a/cr5_moveit/package.xml
+++ b/cr5_moveit/package.xml
@@ -28,7 +28,8 @@
   <exec_depend>xacro</exec_depend>
   <!-- The next 2 packages are required for the gazebo simulation.
        We don't include them by default to prevent installing gazebo and all its dependencies. -->
-  <!-- <exec_depend>joint_trajectory_controller</exec_depend> -->
+  <exec_depend>joint_trajectory_controller</exec_depend>
+  <exec_depend>joint_state_broadcaster</exec_depend>
   <!-- <exec_depend>gazebo_ros_control</exec_depend> -->
   <exec_depend>controller_manager</exec_depend>
   <exec_depend>dobot_rviz</exec_depend>
@@ -42,7 +43,7 @@
   <exec_depend>rviz_common</exec_depend>
   <exec_depend>rviz_default_plugins</exec_depend>
   <exec_depend>tf2_ros</exec_depend>
-  <exec_depend>warehouse_ros_mongo</exec_depend>
+  <exec_depend>warehouse_ros_sqlite</exec_depend>
   <exec_depend>xacro</exec_depend>
 
 

--- a/cr7_moveit/package.xml
+++ b/cr7_moveit/package.xml
@@ -28,7 +28,8 @@
   <exec_depend>xacro</exec_depend>
   <!-- The next 2 packages are required for the gazebo simulation.
        We don't include them by default to prevent installing gazebo and all its dependencies. -->
-  <!-- <exec_depend>joint_trajectory_controller</exec_depend> -->
+  <exec_depend>joint_trajectory_controller</exec_depend>
+  <exec_depend>joint_state_broadcaster</exec_depend>
   <!-- <exec_depend>gazebo_ros_control</exec_depend> -->
   <exec_depend>controller_manager</exec_depend>
   <exec_depend>dobot_rviz</exec_depend>
@@ -42,7 +43,7 @@
   <exec_depend>rviz_common</exec_depend>
   <exec_depend>rviz_default_plugins</exec_depend>
   <exec_depend>tf2_ros</exec_depend>
-  <exec_depend>warehouse_ros_mongo</exec_depend>
+  <exec_depend>warehouse_ros_sqlite</exec_depend>
   <exec_depend>xacro</exec_depend>
 
 

--- a/cra_description/urdf/cr10_robot.xacro
+++ b/cra_description/urdf/cr10_robot.xacro
@@ -431,7 +431,7 @@
     <!-- 在运行demo.launch.py时，需要注释这个ros2_control节点，因为它使用了xxx.ros2_control.xacro来生成了ros2_control节点-->
     <ros2_control name="GazeboSystem" type="system">
         <hardware>
-            <plugin>gazebo_ros2_control/GazeboSystem</plugin>
+            <plugin>gz_ros2_control/GazeboSimSystem</plugin>
         </hardware>
         <joint name="joint1">
             <command_interface name="position">
@@ -497,7 +497,7 @@
 
 
     <gazebo>
-        <plugin filename="libgazebo_ros2_control.so" name="gazebo_ros2_control">
+        <plugin filename="gz_ros2_control-system" name="gz_ros2_control::GazeboSimROS2ControlPlugin">
             <parameters>$(find cr10_moveit)/config/ros2_controllers.yaml</parameters>
             <robot_param_node>robot_state_publisher</robot_param_node>
         </plugin>

--- a/cra_description/urdf/cr10af_robot.xacro
+++ b/cra_description/urdf/cr10af_robot.xacro
@@ -430,7 +430,7 @@
     <!-- 在运行demo.launch.py时，需要注释这个ros2_control节点，因为它使用了xxx.ros2_control.xacro来生成了ros2_control节点-->
     <ros2_control name="GazeboSystem" type="system">
         <hardware>
-            <plugin>gazebo_ros2_control/GazeboSystem</plugin>
+            <plugin>gz_ros2_control/GazeboSimSystem</plugin>
         </hardware>
         <joint name="joint1">
             <command_interface name="position">
@@ -495,7 +495,7 @@
     </ros2_control>
 
     <gazebo>
-        <plugin filename="libgazebo_ros2_control.so" name="gazebo_ros2_control">
+        <plugin filename="gz_ros2_control-system" name="gz_ros2_control::GazeboSimROS2ControlPlugin">
             <parameters>$(find cr10af_moveit)/config/ros2_controllers.yaml</parameters>
             <robot_param_node>robot_state_publisher</robot_param_node>
         </plugin>

--- a/cra_description/urdf/cr12_robot.xacro
+++ b/cra_description/urdf/cr12_robot.xacro
@@ -433,7 +433,7 @@
     <!-- 在运行demo.launch.py时，需要注释这个ros2_control节点，因为它使用了xxx.ros2_control.xacro来生成了ros2_control节点-->
     <ros2_control name="GazeboSystem" type="system">
         <hardware>
-            <plugin>gazebo_ros2_control/GazeboSystem</plugin>
+            <plugin>gz_ros2_control/GazeboSimSystem</plugin>
         </hardware>
         <joint name="joint1">
             <command_interface name="position">
@@ -499,7 +499,7 @@
 
 
     <gazebo>
-        <plugin filename="libgazebo_ros2_control.so" name="gazebo_ros2_control">
+        <plugin filename="gz_ros2_control-system" name="gz_ros2_control::GazeboSimROS2ControlPlugin">
             <parameters>$(find cr12_moveit)/config/ros2_controllers.yaml</parameters>
             <robot_param_node>robot_state_publisher</robot_param_node>
         </plugin>

--- a/cra_description/urdf/cr16_robot.xacro
+++ b/cra_description/urdf/cr16_robot.xacro
@@ -432,7 +432,7 @@
     <!-- 在运行demo.launch.py时，需要注释这个ros2_control节点，因为它使用了xxx.ros2_control.xacro来生成了ros2_control节点-->
     <ros2_control name="GazeboSystem" type="system">
         <hardware>
-            <plugin>gazebo_ros2_control/GazeboSystem</plugin>
+            <plugin>gz_ros2_control/GazeboSimSystem</plugin>
         </hardware>
         <joint name="joint1">
             <command_interface name="position">
@@ -498,7 +498,7 @@
 
 
     <gazebo>
-        <plugin filename="libgazebo_ros2_control.so" name="gazebo_ros2_control">
+        <plugin filename="gz_ros2_control-system" name="gz_ros2_control::GazeboSimROS2ControlPlugin">
             <parameters>$(find cr16_moveit)/config/ros2_controllers.yaml</parameters>
             <robot_param_node>robot_state_publisher</robot_param_node>
         </plugin>

--- a/cra_description/urdf/cr20_robot.xacro
+++ b/cra_description/urdf/cr20_robot.xacro
@@ -427,7 +427,7 @@
     <!-- 在运行demo.launch.py时，需要注释这个ros2_control节点，因为它使用了xxx.ros2_control.xacro来生成了ros2_control节点-->
     <ros2_control name="GazeboSystem" type="system">
         <hardware>
-            <plugin>gazebo_ros2_control/GazeboSystem</plugin>
+            <plugin>gz_ros2_control/GazeboSimSystem</plugin>
         </hardware>
         <joint name="joint1">
             <command_interface name="position">
@@ -493,7 +493,7 @@
 
 
     <gazebo>
-        <plugin filename="libgazebo_ros2_control.so" name="gazebo_ros2_control">
+        <plugin filename="gz_ros2_control-system" name="gz_ros2_control::GazeboSimROS2ControlPlugin">
             <parameters>$(find cr20_moveit)/config/ros2_controllers.yaml</parameters>
             <robot_param_node>robot_state_publisher</robot_param_node>
         </plugin>

--- a/cra_description/urdf/cr30h_robot.xacro
+++ b/cra_description/urdf/cr30h_robot.xacro
@@ -427,7 +427,7 @@
     <!-- 在运行demo.launch.py时，需要注释这个ros2_control节点，因为它使用了xxx.ros2_control.xacro来生成了ros2_control节点-->
     <ros2_control name="GazeboSystem" type="system">
         <hardware>
-            <plugin>gazebo_ros2_control/GazeboSystem</plugin>
+            <plugin>gz_ros2_control/GazeboSimSystem</plugin>
         </hardware>
         <joint name="joint1">
             <command_interface name="position">
@@ -493,7 +493,7 @@
 
 
     <gazebo>
-        <plugin filename="libgazebo_ros2_control.so" name="gazebo_ros2_control">
+        <plugin filename="gz_ros2_control-system" name="gz_ros2_control::GazeboSimROS2ControlPlugin">
             <parameters>$(find cr30h_moveit)/config/ros2_controllers.yaml</parameters>
             <robot_param_node>robot_state_publisher</robot_param_node>
         </plugin>

--- a/cra_description/urdf/cr3_robot.xacro
+++ b/cra_description/urdf/cr3_robot.xacro
@@ -432,7 +432,7 @@
     <!-- 在运行demo.launch.py时，需要注释这个ros2_control节点，因为它使用了xxx.ros2_control.xacro来生成了ros2_control节点-->
     <ros2_control name="GazeboSystem" type="system">
         <hardware>
-            <plugin>gazebo_ros2_control/GazeboSystem</plugin>
+            <plugin>gz_ros2_control/GazeboSimSystem</plugin>
         </hardware>
         <joint name="joint1">
             <command_interface name="position">
@@ -497,7 +497,7 @@
     </ros2_control>
 
     <gazebo>
-        <plugin filename="libgazebo_ros2_control.so" name="gazebo_ros2_control">
+        <plugin filename="gz_ros2_control-system" name="gz_ros2_control::GazeboSimROS2ControlPlugin">
             <parameters>$(find cr3_moveit)/config/ros2_controllers.yaml</parameters>
             <robot_param_node>robot_state_publisher</robot_param_node>
         </plugin>

--- a/cra_description/urdf/cr5_robot.xacro
+++ b/cra_description/urdf/cr5_robot.xacro
@@ -431,7 +431,7 @@
     <!-- 在运行demo.launch.py时，需要注释这个ros2_control节点，因为它使用了xxx.ros2_control.xacro来生成了ros2_control节点-->
     <ros2_control name="GazeboSystem" type="system">
         <hardware>
-            <plugin>gazebo_ros2_control/GazeboSystem</plugin>
+            <plugin>gz_ros2_control/GazeboSimSystem</plugin>
         </hardware>
         <joint name="joint1">
             <command_interface name="position">
@@ -497,7 +497,7 @@
 
 
     <gazebo>
-        <plugin filename="libgazebo_ros2_control.so" name="gazebo_ros2_control">
+        <plugin filename="gz_ros2_control-system" name="gz_ros2_control::GazeboSimROS2ControlPlugin">
             <parameters> $(find cr5_moveit)/config/ros2_controllers.yaml</parameters>
             <robot_param_node>robot_state_publisher</robot_param_node>
         </plugin>

--- a/cra_description/urdf/cr7_robot.xacro
+++ b/cra_description/urdf/cr7_robot.xacro
@@ -431,7 +431,7 @@
     <!-- 在运行demo.launch.py时，需要注释这个ros2_control节点，因为它使用了xxx.ros2_control.xacro来生成了ros2_control节点-->
     <ros2_control name="GazeboSystem" type="system">
         <hardware>
-            <plugin>gazebo_ros2_control/GazeboSystem</plugin>
+            <plugin>gz_ros2_control/GazeboSimSystem</plugin>
         </hardware>
         <joint name="joint1">
             <command_interface name="position">
@@ -497,7 +497,7 @@
 
 
     <gazebo>
-        <plugin filename="libgazebo_ros2_control.so" name="gazebo_ros2_control">
+        <plugin filename="gz_ros2_control-system" name="gz_ros2_control::GazeboSimROS2ControlPlugin">
             <parameters>$(find cr7_moveit)/config/ros2_controllers.yaml</parameters>
             <robot_param_node>robot_state_publisher</robot_param_node>
         </plugin>

--- a/cra_description/urdf/me6_robot.xacro
+++ b/cra_description/urdf/me6_robot.xacro
@@ -259,7 +259,7 @@
     <!-- 在运行demo.launch.py时，需要注释这个ros2_control节点，因为它使用了xxx.ros2_control.xacro来生成了ros2_control节点-->
     <ros2_control name="GazeboSystem" type="system">
         <hardware>
-            <plugin>gazebo_ros2_control/GazeboSystem</plugin>
+            <plugin>gz_ros2_control/GazeboSimSystem</plugin>
         </hardware>
         <joint name="joint1">
             <command_interface name="position">
@@ -325,7 +325,7 @@
 
 
     <gazebo>
-        <plugin filename="libgazebo_ros2_control.so" name="gazebo_ros2_control">
+        <plugin filename="gz_ros2_control-system" name="gz_ros2_control::GazeboSimROS2ControlPlugin">
             <parameters> $(find me6_moveit)/config/ros2_controllers.yaml</parameters>
             <robot_param_node>robot_state_publisher</robot_param_node>
         </plugin>

--- a/cra_description/urdf/nova2_robot.xacro
+++ b/cra_description/urdf/nova2_robot.xacro
@@ -255,7 +255,7 @@
     <!-- 在运行demo.launch.py时，需要注释这个ros2_control节点，因为它使用了xxx.ros2_control.xacro来生成了ros2_control节点-->
     <ros2_control name="GazeboSystem" type="system">
         <hardware>
-            <plugin>gazebo_ros2_control/GazeboSystem</plugin>
+            <plugin>gz_ros2_control/GazeboSimSystem</plugin>
         </hardware>
         <joint name="joint1">
             <command_interface name="position">
@@ -320,7 +320,7 @@
     </ros2_control>
 
     <gazebo>
-        <plugin filename="libgazebo_ros2_control.so" name="gazebo_ros2_control">
+        <plugin filename="gz_ros2_control-system" name="gz_ros2_control::GazeboSimROS2ControlPlugin">
             <parameters> $(find nova2_moveit)/config/ros2_controllers.yaml</parameters>
             <robot_param_node>robot_state_publisher</robot_param_node>
         </plugin>

--- a/cra_description/urdf/nova5_robot.xacro
+++ b/cra_description/urdf/nova5_robot.xacro
@@ -434,7 +434,7 @@
     <!-- 在运行demo.launch.py时，需要注释这个ros2_control节点，因为它使用了xxx.ros2_control.xacro来生成了ros2_control节点-->
     <ros2_control name="GazeboSystem" type="system">
         <hardware>
-            <plugin>gazebo_ros2_control/GazeboSystem</plugin>
+            <plugin>gz_ros2_control/GazeboSimSystem</plugin>
         </hardware>
         <joint name="joint1">
             <command_interface name="position">
@@ -500,7 +500,7 @@
 
 
     <gazebo>
-        <plugin filename="libgazebo_ros2_control.so" name="gazebo_ros2_control">
+        <plugin filename="gz_ros2_control-system" name="gz_ros2_control::GazeboSimROS2ControlPlugin">
             <parameters> $(find nova5_moveit)/config/ros2_controllers.yaml</parameters>
             <robot_param_node>robot_state_publisher</robot_param_node>
         </plugin>

--- a/dobot_gazebo/launch/dobot_gazebo.launch.py
+++ b/dobot_gazebo/launch/dobot_gazebo.launch.py
@@ -2,31 +2,9 @@ import os
 from ament_index_python.packages import get_package_share_directory
 from launch import LaunchDescription
 from launch_ros.actions import Node
-from launch.actions import ExecuteProcess, IncludeLaunchDescription, RegisterEventHandler
-from launch.event_handlers import OnProcessExit
+from launch.actions import IncludeLaunchDescription
 from launch.launch_description_sources import PythonLaunchDescriptionSource
 import xacro
-import yaml
-
-
-def load_file(package_name, file_path):
-    package_path = get_package_share_directory(package_name)
-    absolute_file_path = os.path.join(package_path, file_path)
-    try:
-        with open(absolute_file_path, 'r') as file:
-            return file.read()
-    except EnvironmentError:
-        return None
-
-
-def load_yaml(package_name, file_path):
-    package_path = get_package_share_directory(package_name)
-    absolute_file_path = os.path.join(package_path, file_path)
-    try:
-        with open(absolute_file_path, 'r') as file:
-            return yaml.safe_load(file)
-    except EnvironmentError:
-        return None
 
 
 def generate_launch_description():
@@ -34,11 +12,15 @@ def generate_launch_description():
     robot_name_in_model = f'{name}_robot'
     package_name = 'cra_description'
     urdf_name = f"{name}_robot.xacro"
+
+    # Launch Gazebo (gz sim). empty.sdf ships with a sun, ground plane and the
+    # Physics/SceneBroadcaster/UserCommands system plugins that gz_ros2_control needs.
     gazebo = IncludeLaunchDescription(
-                PythonLaunchDescriptionSource([os.path.join(
-                    get_package_share_directory('gazebo_ros'), 'launch'), '/gazebo.launch.py']),
-                launch_arguments={}.items(),
-             )
+        PythonLaunchDescriptionSource([os.path.join(
+            get_package_share_directory('ros_gz_sim'), 'launch'), '/gz_sim.launch.py']),
+        launch_arguments={'gz_args': '-r empty.sdf'}.items(),
+    )
+
     cra_description_path = os.path.join(
         get_package_share_directory(package_name))
 
@@ -48,7 +30,7 @@ def generate_launch_description():
     doc = xacro.parse(open(xacro_file))
     xacro.process_doc(doc)
     robot_description_config = doc.toxml()
-    robot_description = {'robot_description': robot_description_config}
+    robot_description = {'robot_description': robot_description_config, 'use_sim_time': True}
 
     node_robot_state_publisher = Node(
         package='robot_state_publisher',
@@ -57,13 +39,19 @@ def generate_launch_description():
         parameters=[robot_description]
     )
 
-    spawn_entity = Node(package='gazebo_ros', executable='spawn_entity.py',
+    spawn_entity = Node(package='ros_gz_sim', executable='create',
                         arguments=['-topic', 'robot_description',
-                                   '-entity', robot_name_in_model],
+                                   '-name', robot_name_in_model],
                         output='screen')
-    
+
+    # Bridge gz /clock so ROS nodes share simulation time.
+    clock_bridge = Node(package='ros_gz_bridge', executable='parameter_bridge',
+                        arguments=['/clock@rosgraph_msgs/msg/Clock[gz.msgs.Clock'],
+                        output='screen')
+
     return LaunchDescription([
       gazebo,
+      clock_bridge,
       node_robot_state_publisher,
       spawn_entity
     ])

--- a/dobot_gazebo/launch/gazebo_moveit.launch.py
+++ b/dobot_gazebo/launch/gazebo_moveit.launch.py
@@ -6,27 +6,6 @@ from launch.actions import ExecuteProcess, IncludeLaunchDescription, RegisterEve
 from launch.event_handlers import OnProcessExit
 from launch.launch_description_sources import PythonLaunchDescriptionSource
 import xacro
-import yaml
-
-
-def load_file(package_name, file_path):
-    package_path = get_package_share_directory(package_name)
-    absolute_file_path = os.path.join(package_path, file_path)
-    try:
-        with open(absolute_file_path, 'r') as file:
-            return file.read()
-    except EnvironmentError:
-        return None
-
-
-def load_yaml(package_name, file_path):
-    package_path = get_package_share_directory(package_name)
-    absolute_file_path = os.path.join(package_path, file_path)
-    try:
-        with open(absolute_file_path, 'r') as file:
-            return yaml.safe_load(file)
-    except EnvironmentError:
-        return None
 
 
 def generate_launch_description():
@@ -34,11 +13,15 @@ def generate_launch_description():
     robot_name_in_model = f'{name}_robot'
     package_name = 'cra_description'
     urdf_name = f"{name}_robot.xacro"
+
+    # Launch Gazebo (gz sim). empty.sdf ships with a sun, ground plane and the
+    # Physics/SceneBroadcaster/UserCommands system plugins that gz_ros2_control needs.
     gazebo = IncludeLaunchDescription(
-                PythonLaunchDescriptionSource([os.path.join(
-                    get_package_share_directory('gazebo_ros'), 'launch'), '/gazebo.launch.py']),
-                launch_arguments={}.items(),
-             )
+        PythonLaunchDescriptionSource([os.path.join(
+            get_package_share_directory('ros_gz_sim'), 'launch'), '/gz_sim.launch.py']),
+        launch_arguments={'gz_args': '-r empty.sdf'}.items(),
+    )
+
     cra_description_path = os.path.join(
         get_package_share_directory(package_name))
 
@@ -49,7 +32,7 @@ def generate_launch_description():
     doc = xacro.parse(open(xacro_file))
     xacro.process_doc(doc)
     robot_description_config = doc.toxml()
-    robot_description = {'robot_description': robot_description_config}
+    robot_description = {'robot_description': robot_description_config, 'use_sim_time': True}
 
     node_robot_state_publisher = Node(
         package='robot_state_publisher',
@@ -58,11 +41,18 @@ def generate_launch_description():
         parameters=[robot_description]
     )
 
-    spawn_entity = Node(package='gazebo_ros', executable='spawn_entity.py',
+    spawn_entity = Node(package='ros_gz_sim', executable='create',
                         arguments=['-topic', 'robot_description',
-                                   '-entity', robot_name_in_model],
+                                   '-name', robot_name_in_model],
                         output='screen')
-    
+
+    # Bridge gz /clock so ROS nodes share simulation time.
+    clock_bridge = Node(package='ros_gz_bridge', executable='parameter_bridge',
+                        arguments=['/clock@rosgraph_msgs/msg/Clock[gz.msgs.Clock'],
+                        output='screen')
+
+    # The controller_manager is hosted inside the gz_ros2_control system plugin, so
+    # controllers can only be loaded once the robot has been spawned into Gazebo.
     # # 关节状态发布器
     load_joint_state_controller = ExecuteProcess(
         cmd=['ros2', 'control', 'load_controller', '--set-state', 'active',
@@ -77,7 +67,7 @@ def generate_launch_description():
         output='screen'
     )
 
-    close_evt1 =  RegisterEventHandler( 
+    close_evt1 = RegisterEventHandler(
             event_handler=OnProcessExit(
                 target_action=spawn_entity,
                 on_exit=[load_joint_state_controller],
@@ -94,6 +84,7 @@ def generate_launch_description():
       close_evt1,
       close_evt2,
       gazebo,
+      clock_bridge,
       node_robot_state_publisher,
       spawn_entity
     ])

--- a/dobot_gazebo/launch/sim.launch.py
+++ b/dobot_gazebo/launch/sim.launch.py
@@ -1,0 +1,24 @@
+import os
+from ament_index_python.packages import get_package_share_directory
+from launch import LaunchDescription
+from launch.actions import IncludeLaunchDescription
+from launch.launch_description_sources import PythonLaunchDescriptionSource
+
+
+def generate_launch_description():
+    # Gazebo + arm spawn + ros2_control
+    gazebo = IncludeLaunchDescription(
+        PythonLaunchDescriptionSource([os.path.join(
+            get_package_share_directory('dobot_gazebo'), 'launch'), '/gazebo_moveit.launch.py']),
+    )
+
+    # MoveIt move_group + rviz
+    moveit = IncludeLaunchDescription(
+        PythonLaunchDescriptionSource([os.path.join(
+            get_package_share_directory('dobot_moveit'), 'launch'), '/moveit_gazebo.launch.py']),
+    )
+
+    return LaunchDescription([
+        gazebo,
+        moveit,
+    ])

--- a/dobot_gazebo/package.xml
+++ b/dobot_gazebo/package.xml
@@ -14,11 +14,12 @@
 
   <buildtool_depend>ament_cmake</buildtool_depend>
 
-  <exec_depend>gazebo_plugins</exec_depend>
-  <exec_depend>gazebo_ros</exec_depend>
-  <exec_depend>gazebo_ros2_control</exec_depend>
+  <exec_depend>ros_gz_sim</exec_depend>
+  <exec_depend>ros_gz_bridge</exec_depend>
+  <exec_depend>gz_ros2_control</exec_depend>
   <exec_depend>robot_state_publisher</exec_depend>
   <exec_depend>cra_description</exec_depend>
+  <exec_depend>dobot_moveit</exec_depend>
   <exec_depend>xacro</exec_depend>
 
   <export>

--- a/me6_moveit/package.xml
+++ b/me6_moveit/package.xml
@@ -28,7 +28,8 @@
   <exec_depend>xacro</exec_depend>
   <!-- The next 2 packages are required for the gazebo simulation.
        We don't include them by default to prevent installing gazebo and all its dependencies. -->
-  <!-- <exec_depend>joint_trajectory_controller</exec_depend> -->
+  <exec_depend>joint_trajectory_controller</exec_depend>
+  <exec_depend>joint_state_broadcaster</exec_depend>
   <!-- <exec_depend>gazebo_ros_control</exec_depend> -->
   <exec_depend>controller_manager</exec_depend>
   <exec_depend>dobot_rviz</exec_depend>
@@ -42,7 +43,7 @@
   <exec_depend>rviz_common</exec_depend>
   <exec_depend>rviz_default_plugins</exec_depend>
   <exec_depend>tf2_ros</exec_depend>
-  <exec_depend>warehouse_ros_mongo</exec_depend>
+  <exec_depend>warehouse_ros_sqlite</exec_depend>
   <exec_depend>xacro</exec_depend>
 
 

--- a/nova2_moveit/package.xml
+++ b/nova2_moveit/package.xml
@@ -28,7 +28,8 @@
   <exec_depend>xacro</exec_depend>
   <!-- The next 2 packages are required for the gazebo simulation.
        We don't include them by default to prevent installing gazebo and all its dependencies. -->
-  <!-- <exec_depend>joint_trajectory_controller</exec_depend> -->
+  <exec_depend>joint_trajectory_controller</exec_depend>
+  <exec_depend>joint_state_broadcaster</exec_depend>
   <!-- <exec_depend>gazebo_ros_control</exec_depend> -->
   <exec_depend>controller_manager</exec_depend>
   <exec_depend>dobot_rviz</exec_depend>
@@ -42,7 +43,7 @@
   <exec_depend>rviz_common</exec_depend>
   <exec_depend>rviz_default_plugins</exec_depend>
   <exec_depend>tf2_ros</exec_depend>
-  <exec_depend>warehouse_ros_mongo</exec_depend>
+  <exec_depend>warehouse_ros_sqlite</exec_depend>
   <exec_depend>xacro</exec_depend>
 
 

--- a/nova5_moveit/package.xml
+++ b/nova5_moveit/package.xml
@@ -28,7 +28,8 @@
   <exec_depend>xacro</exec_depend>
   <!-- The next 2 packages are required for the gazebo simulation.
        We don't include them by default to prevent installing gazebo and all its dependencies. -->
-  <!-- <exec_depend>joint_trajectory_controller</exec_depend> -->
+  <exec_depend>joint_trajectory_controller</exec_depend>
+  <exec_depend>joint_state_broadcaster</exec_depend>
   <!-- <exec_depend>gazebo_ros_control</exec_depend> -->
   <exec_depend>controller_manager</exec_depend>
   <exec_depend>dobot_rviz</exec_depend>
@@ -42,7 +43,7 @@
   <exec_depend>rviz_common</exec_depend>
   <exec_depend>rviz_default_plugins</exec_depend>
   <exec_depend>tf2_ros</exec_depend>
-  <exec_depend>warehouse_ros_mongo</exec_depend>
+  <exec_depend>warehouse_ros_sqlite</exec_depend>
   <exec_depend>xacro</exec_depend>
 
 


### PR DESCRIPTION
Migrate the simulation stack from Gazebo Classic to Gazebo Sim:

- `xacro`: replace `gazebo_ros2_control`/`GazeboSystem` with `gz_ros2_control`/`GazeboSimSystem` and the `libgazebo_ros2_control` plugin with `gz_ros2_control-system` across all robot descriptions
- `dobot_gazebo`/`package.xml`: depend on `ros_gz_sim`, `ros_gz_bridge` and `gz_ros2_control` instead of `gazebo_plugins`/`gazebo_ros`/`gazebo_ros2_control`
- `*_moveit/package.xml`: enable joint_trajectory_controller and joint_state_broadcaster, and switch `warehouse_ros_mongo` to `warehouse_ros_sqlite`
- update `dobot_gazebo` launch files for Gazebo Sim and add `sim.launch.py` to simplify the rviz/ros2 process